### PR TITLE
do not try and render a child if it is falsey

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -27,6 +27,9 @@ export default class DialogContainer extends React.PureComponent {
     const buttonChildrens = [];
     const otherChildrens = [];
     React.Children.forEach(children, child => {
+      if (!child) {
+        return;
+      }
       if (
         child.type.name === "DialogTitle" ||
         child.type.displayName === "DialogTitle"
@@ -37,7 +40,7 @@ export default class DialogContainer extends React.PureComponent {
         child.type.displayName === "DialogDescription"
       ) {
         descriptionChildrens.push(child);
-      } else if ( 
+      } else if (
         child.type.name === "DialogButton" ||
         child.type.displayName === "DialogButton"
       ) {


### PR DESCRIPTION
if you do something like:

```
<Dialog.Component>
  {title && Dialog.Title}
</Dialog.Component>
```

Then if you title is not provided it would blow up. We should filter out falsey evaluations in a render method.