### PR TITLE
Fix onBackdropPress

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -110,7 +110,6 @@ const styles = StyleSheet.create({
     marginBottom: 0
   },
   container: {
-    flex: 1,
     justifyContent: "center",
     alignItems: "center"
   },


### PR DESCRIPTION
Right now if you try to use this prop `onBackdropPress`from react-native-modal, it doesn't work because the container is blocking the whole screen, if we remove `flex: 1`it works and there is no graphical alteration.