### PR TITLE
react-native-web support

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -59,6 +59,10 @@ const styles = StyleSheet.create({
     android: {
       justifyContent: "center",
       alignItems: "center"
+    },
+    web: {
+      justifyContent: "center",
+      alignItems: "center"
     }
   }),
   text: Platform.select({
@@ -68,6 +72,12 @@ const styles = StyleSheet.create({
       backgroundColor: "transparent"
     },
     android: {
+      textAlign: "center",
+      backgroundColor: "transparent",
+      padding: 8,
+      fontSize: 14
+    },
+    web: {
       textAlign: "center",
       backgroundColor: "transparent",
       padding: 8,

--- a/src/Container.js
+++ b/src/Container.js
@@ -139,6 +139,16 @@ const styles = StyleSheet.create({
       overflow: "hidden",
       elevation: 4,
       minWidth: 300
+    },
+    web: {
+      flexDirection: "column",
+      borderRadius: 3,
+      padding: 16,
+      margin: 16,
+      backgroundColor: "white",
+      overflow: "hidden",
+      elevation: 4,
+      minWidth: 300
     }
   }),
   header: Platform.select({
@@ -146,6 +156,9 @@ const styles = StyleSheet.create({
       margin: 18
     },
     android: {
+      margin: 12
+    },
+    web: {
       margin: 12
     }
   }),
@@ -162,6 +175,12 @@ const styles = StyleSheet.create({
       alignItems: "center",
       justifyContent: "flex-end",
       marginTop: 4
+    },
+    web: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "flex-end",
+        marginTop: 4
     }
   }),
   buttonSeparator: {

--- a/src/Description.js
+++ b/src/Description.js
@@ -33,6 +33,11 @@ const styles = StyleSheet.create({
       color: "#33383D",
       fontSize: 16,
       marginTop: 10
+    },
+    web: {
+      color: "#33383D",
+      fontSize: 16,
+      marginTop: 10
     }
   })
 });

--- a/src/Title.js
+++ b/src/Title.js
@@ -32,6 +32,10 @@ const styles = StyleSheet.create({
     android: {
       fontWeight: "500",
       fontSize: 18
+    },
+    web: {
+      fontWeight: "500",
+      fontSize: 18
     }
   })
 });


### PR DESCRIPTION
```
resolve: {
    // This will only alias the exact import "react-native"
    alias: {
      'react-native$': 'react-native-web',
     ...
      'react-native-modal': 'modal-enhanced-react-native-web',
      ...
    },
    // If you're working on a multi-platform React Native app, web-specific
    // module implementations should be written in files using the extension
    // `.web.js`.
    extensions: [ '.web.js', '.js' ]
  },
```

Adding support for react-native-web. Make sure to alias react-native-modal to modal-enhanced-react-native-web in the original app's webpack.config.js for this to work properly