### PR TITLE
Fixed backdrop press and animation on close

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -48,7 +48,7 @@ const DialogContainer = (props) => {
     }
   });
   return (
-    <Modal transparent={true} visible={visible} {...nodeProps}>
+    <Modal renderToHardwareTextureAndroid={true} transparent={true} visible={visible} {...nodeProps}>
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : undefined}
         style={styles.centeredView}
@@ -102,7 +102,6 @@ const styles = StyleSheet.create({
     marginBottom: 0,
   },
   centeredView: {
-    flex: 1,
     justifyContent: "center",
     alignItems: "center",
     marginTop: 22,

--- a/src/Container.js
+++ b/src/Container.js
@@ -48,7 +48,12 @@ const DialogContainer = (props) => {
     }
   });
   return (
-    <Modal renderToHardwareTextureAndroid={true} transparent={true} visible={visible} {...nodeProps}>
+    <Modal
+      renderToHardwareTextureAndroid={true}
+      transparent={true}
+      visible={visible}
+      {...nodeProps}
+    >
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : undefined}
         style={styles.centeredView}

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -217,8 +217,8 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center'
+    alignItems: "center",
+    justifyContent: "center"
   },
 });
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -199,6 +199,7 @@ export class Modal extends Component {
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     position: "absolute",
     top: 0,
     left: 0,
@@ -216,6 +217,8 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
   },
 });
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -218,7 +218,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     alignItems: "center",
-    justifyContent: "center"
+    justifyContent: "center",
   },
 });
 


### PR DESCRIPTION
Backdrop was not clickable because centeredView had `flex:1` so I fixed removing the `flex` property making the background clickable.
When closing the dialog on Android 9, the elevation of the view didn't animate, making it look weird, so I added `renderToHardwareTextureAndroid={true}` to `<Modal/>` to solve this bug.