### PR TITLE
[Fix] Translucent modal doesn't cover whole screen height

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, Dimensions, StatusBar, StyleSheet, View } from "react-native";
+import { Button, StyleSheet, View } from "react-native";
 import Dialog from "react-native-dialog";
 
 export default function App() {
@@ -19,12 +19,10 @@ export default function App() {
     setVisible(false);
   };
 
-  const RealDeviceHeight = Dimensions.get('window').height + (StatusBar.currentHeight ?? 0);
-
   return (
     <View style={styles.container}>
       <Button title="Show dialog" onPress={showDialog} />
-      <Dialog.Container visible={visible} statusBarTranslucent deviceHeight={RealDeviceHeight}>
+      <Dialog.Container visible={visible} statusBarTranslucent>
         <Dialog.Title>Account delete</Dialog.Title>
         <Dialog.Description>
           Do you want to delete this account? You cannot undo this action.

--- a/example/App.js
+++ b/example/App.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, StyleSheet, View } from "react-native";
+import { Button, Dimensions, StatusBar, StyleSheet, View } from "react-native";
 import Dialog from "react-native-dialog";
 
 export default function App() {
@@ -19,10 +19,12 @@ export default function App() {
     setVisible(false);
   };
 
+  const RealDeviceHeight = Dimensions.get('window').height + (StatusBar.currentHeight ?? 0);
+
   return (
     <View style={styles.container}>
       <Button title="Show dialog" onPress={showDialog} />
-      <Dialog.Container visible={visible}>
+      <Dialog.Container visible={visible} statusBarTranslucent deviceHeight={RealDeviceHeight}>
         <Dialog.Title>Account delete</Dialog.Title>
         <Dialog.Description>
           Do you want to delete this account? You cannot undo this action.

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -131,7 +131,6 @@ export class Modal extends Component {
       children,
       onBackdropPress,
       contentStyle,
-      style,
       ...otherProps
     } = this.props;
     const { currentAnimation, visible } = this.state;
@@ -173,7 +172,6 @@ export class Modal extends Component {
       <ReactNativeModal
         transparent
         animationType="none"
-        style={StyleSheet.compose(styles.modal, style)}
         {...otherProps}
         visible={visible}
       >
@@ -201,9 +199,6 @@ export class Modal extends Component {
 }
 
 const styles = StyleSheet.create({
-  modal: {
-    margin: 0,
-  },
   backdrop: {
     position: "absolute",
     top: 0,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -207,8 +207,6 @@ const styles = StyleSheet.create({
     right: 0,
     backgroundColor: "black",
     opacity: 0,
-    width: "100%",
-    height: "100%",
   },
   content: {
     flex: 1,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,8 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import {
   Animated,
-  DeviceEventEmitter,
-  Dimensions,
   Easing,
   Modal as ReactNativeModal,
   Platform,
@@ -73,8 +71,6 @@ export class Modal extends Component {
   state = {
     visible: this.props.visible,
     currentAnimation: "none",
-    deviceWidth: Dimensions.get("window").width,
-    deviceHeight: Dimensions.get("window").height,
   };
 
   animVal = new Animated.Value(0);
@@ -85,17 +81,9 @@ export class Modal extends Component {
     if (this.state.visible) {
       this.show();
     }
-    DeviceEventEmitter.addListener(
-      "didUpdateDimensions",
-      this.handleDimensionsUpdate
-    );
   }
 
   componentWillUnmount() {
-    DeviceEventEmitter.removeListener(
-      "didUpdateDimensions",
-      this.handleDimensionsUpdate
-    );
     this._isMounted = false;
   }
 
@@ -106,17 +94,6 @@ export class Modal extends Component {
       this.hide();
     }
   }
-
-  handleDimensionsUpdate = (dimensionsUpdate) => {
-    const deviceWidth = dimensionsUpdate.window.width;
-    const deviceHeight = dimensionsUpdate.window.height;
-    if (
-      deviceWidth !== this.state.deviceWidth ||
-      deviceHeight !== this.state.deviceHeight
-    ) {
-      this.setState({ deviceWidth, deviceHeight });
-    }
-  };
 
   show = () => {
     this.setState({ visible: true, currentAnimation: "in" }, () => {
@@ -154,9 +131,10 @@ export class Modal extends Component {
       children,
       onBackdropPress,
       contentStyle,
+      style,
       ...otherProps
     } = this.props;
-    const { currentAnimation, deviceHeight, deviceWidth, visible } = this.state;
+    const { currentAnimation, visible } = this.state;
 
     const backdropAnimatedStyle = {
       opacity: this.animVal.interpolate({
@@ -195,17 +173,12 @@ export class Modal extends Component {
       <ReactNativeModal
         transparent
         animationType="none"
+        style={StyleSheet.compose(styles.modal, style)}
         {...otherProps}
         visible={visible}
       >
         <TouchableWithoutFeedback onPress={onBackdropPress}>
-          <Animated.View
-            style={[
-              styles.backdrop,
-              backdropAnimatedStyle,
-              { width: deviceWidth, height: deviceHeight },
-            ]}
-          />
+          <Animated.View style={[styles.backdrop, backdropAnimatedStyle]} />
         </TouchableWithoutFeedback>
         {visible && (
           <Animated.View
@@ -228,6 +201,9 @@ export class Modal extends Component {
 }
 
 const styles = StyleSheet.create({
+  modal: {
+    margin: 0,
+  },
   backdrop: {
     position: "absolute",
     top: 0,
@@ -236,6 +212,8 @@ const styles = StyleSheet.create({
     right: 0,
     backgroundColor: "black",
     opacity: 0,
+    width: "100%",
+    height: "100%",
   },
   content: {
     flex: 1,


### PR DESCRIPTION
# Overview

When setting `statusBarTranslucent` to `true` in `Dialog.Container` to use translucent status bar, The modal doesn't cover the whole screen height and a gab appears in the bottom of screen. This issue happens since `Dimensions` window API returns the device height without considering status bar height.

# Test Plan

- I updated the example app to use translucent modal. For testing please run the following commands after cloning this repo:

```shell
$ cd react-native-dialog
$ cd example
$ npm install
$ npm run android
```
- Press `SHOW DIALOG` button to see the bottom gab
- Run the following command `npm run sync` to add this fix and test again.
