### PR TITLE
feat: add keyboardVerticalOffset support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,17 @@ const styles = StyleSheet.create({
 
 ### Dialog.Container props
 
-| Name                 | Type | Default                | Description                                        |
-| -------------------- | ---- | ---------------------- | -------------------------------------------------- |
-| blurComponentIOS     | node | A low-opacity <View /> | The blur component used in iOS                     |
-| visible              | bool | **REQUIRED**           | Show the dialog?                                   |
-| children             | node | **REQUIRED**           | The dialog content                                 |
-| contentStyle         | any  | undefined              | Extra style applied to the dialog content          |
-| headerStyle          | any  | undefined              | Extra style applied to the dialog header           |
-| footerStyle          | any  | undefined              | Extra style applied to the dialog footer           |
-| buttonSeparatorStyle | any  | undefined              | Extra style applied to the dialog button separator |
-| onBackdropPress      | func | undefined              | Callback invoked when the backdrop is pressed      |
+| Name                   | Type   | Default                | Description                                        |
+| ---------------------- | ------ | ---------------------- | -------------------------------------------------- |
+| blurComponentIOS       | node   | A low-opacity <View /> | The blur component used in iOS                     |
+| visible                | bool   | **REQUIRED**           | Show the dialog?                                   |
+| children               | node   | **REQUIRED**           | The dialog content                                 |
+| contentStyle           | any    | undefined              | Extra style applied to the dialog content          |
+| headerStyle            | any    | undefined              | Extra style applied to the dialog header           |
+| footerStyle            | any    | undefined              | Extra style applied to the dialog footer           |
+| buttonSeparatorStyle   | any    | undefined              | Extra style applied to the dialog button separator |
+| onBackdropPress        | func   | undefined              | Callback invoked when the backdrop is pressed      |
+| keyboardVerticalOffset | number | undefined              | keyboardVerticalOffset for iOS                     |
 
 ### Dialog.Input props
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dialog",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "A flexible react-native dialog",
   "main": "src/index.js",
   "author": "Mazzarolo Matteo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dialog",
-  "version": "6.1.3",
+  "version": "6.1.2",
   "description": "A flexible react-native dialog",
   "main": "src/index.js",
   "author": "Mazzarolo Matteo",

--- a/src/Container.js
+++ b/src/Container.js
@@ -3,6 +3,8 @@ import React from "react";
 import { KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native";
 import Modal from "./Modal";
 
+const iOS = Platform.OS === "ios";
+
 const DialogContainer = (props) => {
   const {
     blurComponentIOS,
@@ -13,6 +15,7 @@ const DialogContainer = (props) => {
     headerStyle = {},
     blurStyle = {},
     visible,
+    keyboardVerticalOffset = 40,
     ...nodeProps
   } = props;
   const titleChildrens = [];
@@ -55,7 +58,8 @@ const DialogContainer = (props) => {
       {...nodeProps}
     >
       <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        behavior={iOS ? "padding" : undefined}
+        keyboardVerticalOffset={iOS ? keyboardVerticalOffset : undefined}
         style={styles.centeredView}
       >
         <View style={[styles.content, contentStyle]}>


### PR DESCRIPTION
# Overview

For now, the dialog with input subcomponent display like this on iPhone 12. We need add a space area between dialog bottom and keyboard.
![Bijiabo 2021-02-19 at 23 03 03](https://user-images.githubusercontent.com/2999386/108521553-d1b17c80-7306-11eb-859d-b62b36d0ce16.png)

like this:

![Bijiabo 2021-02-19 at 23 05 56](https://user-images.githubusercontent.com/2999386/108521795-0faea080-7307-11eb-9935-70cac5f9d712.png)


# Solution

Add the keyboardVerticalOffset property support, the default value is 40. Only need modify it on iOS.