### PR TITLE
verticalButtons prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/react-native-dialog.svg)](https://badge.fury.io/js/react-native-dialog)
 
-A flexible pure JavaScript React-Native dialog that follows closely the native UI guidelines. 
+A flexible pure JavaScript React-Native dialog that follows closely the native UI guidelines.
 
 ## Features
 
@@ -174,6 +174,7 @@ const styles = StyleSheet.create({
 | buttonSeparatorStyle   | any    | undefined              | Extra style applied to the dialog button separator |
 | onBackdropPress        | func   | undefined              | Callback invoked when the backdrop is pressed      |
 | keyboardVerticalOffset | number | undefined              | keyboardVerticalOffset for iOS                     |
+| verticalButtons        | bool   | false                  | Renders button vertically                          |
 
 ### Dialog.Input props
 

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -21,13 +21,7 @@ export interface DialogButtonProps extends TextProps {
   onPress: () => void;
 }
 
-export interface DialogButtonHiddenProps {
-  vertical?: boolean;
-}
-
-const DialogButton: React.FC<DialogButtonProps & DialogButtonHiddenProps> = (
-  props
-) => {
+const DialogButton: React.FC<DialogButtonProps> = (props) => {
   const {
     label,
     color = COLOR,
@@ -35,7 +29,6 @@ const DialogButton: React.FC<DialogButtonProps & DialogButtonHiddenProps> = (
     bold,
     onPress,
     style,
-    vertical = false,
     ...nodeProps
   } = props;
   const fontWeight = bold ? "600" : "normal";
@@ -43,7 +36,7 @@ const DialogButton: React.FC<DialogButtonProps & DialogButtonHiddenProps> = (
 
   return (
     <TouchableOpacity
-      style={[styles.button, vertical ? styles.buttonVertical : null]}
+      style={[styles.button]}
       onPress={onPress}
       disabled={disabled}
     >
@@ -72,12 +65,11 @@ const buildStyles: StyleBuilder = (isDark) =>
   StyleSheet.create({
     button: Platform.select({
       ios: {
-        flex: 1,
+        flexGrow: 1,
+        flexShrink: 1,
+        height: 46,
         justifyContent: "center",
         alignItems: "center",
-        padding: 12.5,
-        borderTopColor: PlatformColor("separator"), //"#A9ADAE",
-        borderTopWidth: StyleSheet.hairlineWidth,
       },
       android: {
         justifyContent: "center",
@@ -86,12 +78,6 @@ const buildStyles: StyleBuilder = (isDark) =>
       web: {
         justifyContent: "center",
         alignItems: "center",
-      },
-      default: {},
-    }),
-    buttonVertical: Platform.select({
-      ios: {
-        flex: 0,
       },
       default: {},
     }),

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -21,7 +21,13 @@ export interface DialogButtonProps extends TextProps {
   onPress: () => void;
 }
 
-const DialogButton: React.FC<DialogButtonProps> = (props) => {
+export interface DialogButtonHiddenProps {
+  vertical?: boolean;
+}
+
+const DialogButton: React.FC<DialogButtonProps & DialogButtonHiddenProps> = (
+  props
+) => {
   const {
     label,
     color = COLOR,
@@ -29,6 +35,7 @@ const DialogButton: React.FC<DialogButtonProps> = (props) => {
     bold,
     onPress,
     style,
+    vertical = false,
     ...nodeProps
   } = props;
   const fontWeight = bold ? "600" : "normal";
@@ -36,7 +43,7 @@ const DialogButton: React.FC<DialogButtonProps> = (props) => {
 
   return (
     <TouchableOpacity
-      style={styles.button}
+      style={[styles.button, vertical ? styles.buttonVertical : null]}
       onPress={onPress}
       disabled={disabled}
     >
@@ -68,6 +75,9 @@ const buildStyles: StyleBuilder = (isDark) =>
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
+        padding: 12.5,
+        borderTopColor: PlatformColor("separator"), //"#A9ADAE",
+        borderTopWidth: StyleSheet.hairlineWidth,
       },
       android: {
         justifyContent: "center",
@@ -76,6 +86,12 @@ const buildStyles: StyleBuilder = (isDark) =>
       web: {
         justifyContent: "center",
         alignItems: "center",
+      },
+      default: {},
+    }),
+    buttonVertical: Platform.select({
+      ios: {
+        flex: 0,
       },
       default: {},
     }),

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -65,13 +65,16 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
       child.type.name === "DialogButton" ||
       child.type.displayName === "DialogButton"
     ) {
-      if (
-        !verticalButtons &&
-        Platform.OS === "ios" &&
-        buttonChildrens.length > 0
-      ) {
+      if (Platform.OS === "ios" && buttonChildrens.length > 0) {
         buttonChildrens.push(
-          <View style={[styles.buttonSeparator, buttonSeparatorStyle]} />
+          <View
+            style={[
+              verticalButtons
+                ? styles.buttonSeparatorVertical
+                : styles.buttonSeparatorHorizontal,
+              buttonSeparatorStyle,
+            ]}
+          />
         );
       }
       buttonChildrens.push(child);
@@ -102,20 +105,24 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
           </View>
           {otherChildrens}
           {Boolean(buttonChildrens.length) && (
-            <View
-              style={[
-                styles.footer,
-                verticalButtons ? styles.footerVertical : null,
-                footerStyle,
-              ]}
-            >
-              {buttonChildrens.map((x, i) =>
-                React.cloneElement(x, {
-                  key: `dialog-button-${i}`,
-                  vertical: verticalButtons,
-                })
+            <>
+              {Platform.OS === "ios" && (
+                <View style={styles.buttonSeparatorVertical} />
               )}
-            </View>
+              <View
+                style={[
+                  styles.footer,
+                  verticalButtons ? styles.footerVertical : null,
+                  footerStyle,
+                ]}
+              >
+                {buttonChildrens.map((x, i) =>
+                  React.cloneElement(x, {
+                    key: `dialog-button-${i}`,
+                  })
+                )}
+              </View>
+            </>
           )}
         </View>
       </KeyboardAvoidingView>
@@ -215,10 +222,15 @@ const buildStyles: StyleBuilder = () =>
     footerVertical: {
       flexDirection: "column",
     },
-    buttonSeparator: {
+    buttonSeparatorHorizontal: {
       height: "100%",
       backgroundColor: PlatformColor("separator"), //"#A9ADAE",
       width: StyleSheet.hairlineWidth,
+    },
+    buttonSeparatorVertical: {
+      width: "100%",
+      backgroundColor: PlatformColor("separator"), //"#A9ADAE",
+      height: StyleSheet.hairlineWidth,
     },
   });
 

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -22,6 +22,7 @@ export interface DialogContainerProps {
   headerStyle?: ViewStyle;
   blurStyle?: ViewStyle;
   visible?: boolean;
+  verticalButtons?: boolean;
   onBackdropPress?: () => void;
   keyboardVerticalOffset?: number;
   children: ReactElement<any, NamedExoticComponent>[];
@@ -37,6 +38,7 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
     headerStyle = {},
     blurStyle = {},
     visible = false,
+    verticalButtons = false,
     keyboardVerticalOffset = 40,
     ...nodeProps
   } = props;
@@ -63,7 +65,11 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
       child.type.name === "DialogButton" ||
       child.type.displayName === "DialogButton"
     ) {
-      if (Platform.OS === "ios" && buttonChildrens.length > 0) {
+      if (
+        !verticalButtons &&
+        Platform.OS === "ios" &&
+        buttonChildrens.length > 0
+      ) {
         buttonChildrens.push(
           <View style={[styles.buttonSeparator, buttonSeparatorStyle]} />
         );
@@ -96,10 +102,17 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
           </View>
           {otherChildrens}
           {Boolean(buttonChildrens.length) && (
-            <View style={[styles.footer, footerStyle]}>
+            <View
+              style={[
+                styles.footer,
+                verticalButtons ? styles.footerVertical : null,
+                footerStyle,
+              ]}
+            >
               {buttonChildrens.map((x, i) =>
                 React.cloneElement(x, {
                   key: `dialog-button-${i}`,
+                  vertical: verticalButtons,
                 })
               )}
             </View>
@@ -118,6 +131,7 @@ DialogContainer.propTypes = {
   headerStyle: PropTypes.object,
   blurStyle: PropTypes.object,
   visible: PropTypes.bool,
+  verticalButtons: PropTypes.bool,
   onBackdropPress: PropTypes.func,
   keyboardVerticalOffset: PropTypes.number,
   // @ts-expect-error: PropType allows strings and the Typescript interface does not
@@ -179,28 +193,28 @@ const buildStyles: StyleBuilder = () =>
       },
       default: {},
     }),
-    footer: Platform.select({
-      ios: {
-        flexDirection: "row",
-        justifyContent: "space-between",
-        borderTopColor: PlatformColor("separator"), //"#A9ADAE",
-        borderTopWidth: StyleSheet.hairlineWidth,
-        height: 46,
-      },
-      android: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "flex-end",
-        marginTop: 4,
-      },
-      web: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "flex-end",
-        marginTop: 4,
-      },
-      default: {},
-    }),
+    footer: {
+      flexDirection: "row",
+      ...Platform.select({
+        ios: {
+          justifyContent: "space-between",
+        },
+        android: {
+          alignItems: "center",
+          justifyContent: "flex-end",
+          marginTop: 4,
+        },
+        web: {
+          alignItems: "center",
+          justifyContent: "flex-end",
+          marginTop: 4,
+        },
+        default: {},
+      }),
+    },
+    footerVertical: {
+      flexDirection: "column",
+    },
     buttonSeparator: {
       height: "100%",
       backgroundColor: PlatformColor("separator"), //"#A9ADAE",

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -142,12 +142,8 @@ export class Modal extends Component<ModalProps, ModalState> {
   };
 
   render() {
-    const {
-      children,
-      onBackdropPress,
-      contentStyle,
-      ...otherProps
-    } = this.props;
+    const { children, onBackdropPress, contentStyle, ...otherProps } =
+      this.props;
     const { currentAnimation, visible } = this.state;
 
     const backdropAnimatedStyle = {

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -142,8 +142,12 @@ export class Modal extends Component<ModalProps, ModalState> {
   };
 
   render() {
-    const { children, onBackdropPress, contentStyle, ...otherProps } =
-      this.props;
+    const {
+      children,
+      onBackdropPress,
+      contentStyle,
+      ...otherProps
+    } = this.props;
     const { currentAnimation, visible } = this.state;
 
     const backdropAnimatedStyle = {


### PR DESCRIPTION
# Overview

`verticalButtons`: changes the design so the buttons are vertical instead of horizontal

Related to #47, but I did the change before seeing the issue
Replaces #108 

| iOS default | iOS vertical | Android default | Android vertical |
|:---:|:---:|:--:|:--:|
| ![Simulator Screen Shot - iPhone 11 - 2021-07-08 at 10 13 02](https://user-images.githubusercontent.com/143615/124967367-31b86f00-dfd9-11eb-82c7-fcd90609b02a.png) | ![Simulator Screen Shot - iPhone 11 - 2021-07-08 at 10 17 15](https://user-images.githubusercontent.com/143615/124967405-3c730400-dfd9-11eb-852d-64c8fb4cb53b.png) | ![Screenshot_1625764777](https://user-images.githubusercontent.com/143615/124967551-67f5ee80-dfd9-11eb-9d6c-3cbaaad3feca.png) | ![Screenshot_1625764786](https://user-images.githubusercontent.com/143615/124967584-717f5680-dfd9-11eb-8c84-5ebb562661c7.png)

