### PR TITLE
fix(title): children prop allows node instead of string

### DIFF
--- a/src/Title.tsx
+++ b/src/Title.tsx
@@ -30,7 +30,7 @@ const DialogTitle: React.FC<DialogTitleProps> = (props) => {
 DialogTitle.propTypes = {
   ...TextPropTypes,
   style: PropTypes.any,
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 DialogTitle.displayName = "DialogTitle";


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Fixed #106.

Although type definition declared `props.children` as `ReactNode`, but `DialogTitle.propTypes` still declaring children should be `string`, this will caused React props type check warning while giving ReactNode (object) into `props.children`. 
This PR fix it by making Dialog.Title.propTypes.children as `PropTypes.node.isRequired`.

# Test Plan

This change only affect React props type checking, won't change any functionality.
If any test is needed, please tell me.

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

<!-- NOTES ON CUSTOMIZATIONS: The goal of this library is to achieve a native look and feeling. At the current state we're not looking into increasing the customization options. If you're exposing new customizations options, please let us know in details WHY you think they're needed. Thanks! -->
