### PR TITLE
fix: Handle Hardware Back Button on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,18 +163,19 @@ const styles = StyleSheet.create({
 
 ### Dialog.Container props
 
-| Name                   | Type   | Default                | Description                                        |
-| ---------------------- | ------ | ---------------------- | -------------------------------------------------- |
-| blurComponentIOS       | node   | A low-opacity <View /> | The blur component used in iOS                     |
-| visible                | bool   | **REQUIRED**           | Show the dialog?                                   |
-| children               | node   | **REQUIRED**           | The dialog content                                 |
-| contentStyle           | any    | undefined              | Extra style applied to the dialog content          |
-| headerStyle            | any    | undefined              | Extra style applied to the dialog header           |
-| footerStyle            | any    | undefined              | Extra style applied to the dialog footer           |
-| buttonSeparatorStyle   | any    | undefined              | Extra style applied to the dialog button separator |
-| onBackdropPress        | func   | undefined              | Callback invoked when the backdrop is pressed      |
-| keyboardVerticalOffset | number | undefined              | keyboardVerticalOffset for iOS                     |
-| verticalButtons        | bool   | false                  | Renders button vertically                          |
+| Name                   | Type   | Default       | Description                                                                                         |
+| ---------------------- | ------ | ------------- | --------------------------------------------------------------------------------------------------- |
+| blurComponentIOS       | node   | A low-opacity | The blur component used in iOS                                                                      |
+| visible                | bool   | **REQUIRED**  | Show the dialog?                                                                                    |
+| children               | node   | **REQUIRED**  | The dialog content                                                                                  |
+| contentStyle           | any    | undefined     | Extra style applied to the dialog content                                                           |
+| headerStyle            | any    | undefined     | Extra style applied to the dialog header                                                            |
+| footerStyle            | any    | undefined     | Extra style applied to the dialog footer                                                            |
+| buttonSeparatorStyle   | any    | undefined     | Extra style applied to the dialog button separator                                                  |
+| onBackdropPress        | func   | undefined     | Callback invoked when the backdrop is pressed                                                       |
+| onRequestClose         | func   | undefined     | Callback invoked when the hardware back button on Android or the menu button on Apple TV is pressed |
+| keyboardVerticalOffset | number | undefined     | keyboardVerticalOffset for iOS                                                                      |
+| verticalButtons        | bool   | false         | Renders button vertically                                                                           |
 
 ### Dialog.Input props
 

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -24,6 +24,7 @@ export interface DialogContainerProps {
   visible?: boolean;
   verticalButtons?: boolean;
   onBackdropPress?: () => void;
+  onRequestClose?: () => void;
   keyboardVerticalOffset?: number;
   children: ReactElement<any, NamedExoticComponent>[];
 }

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -142,12 +142,8 @@ export class Modal extends Component<ModalProps, ModalState> {
   };
 
   render() {
-    const {
-      children,
-      onBackdropPress,
-      contentStyle,
-      ...otherProps
-    } = this.props;
+    const { children, onBackdropPress, contentStyle, ...otherProps } =
+      this.props;
     const { currentAnimation, visible } = this.state;
 
     const backdropAnimatedStyle = {


### PR DESCRIPTION
# Overview

1. Add `onRequestClose` on container component, as mentioned [here](https://github.com/mmazzarolo/react-native-dialog/issues/111#issuecomment-878047960)
- Purpose: To handle **hardware back button** event on Android
- Resolves #111 
2. Fixes prettier error in `Modal`

# Test Plan

1. Try adding `onRequestClose` props on `Dialog.Container`.
2. Run the app on Android
3. Show the dialog
4. Press hardware back button
5. Check whether the function gets called 

GIF:
<img alt="" width="300" src="https://user-images.githubusercontent.com/46070698/126048174-771645d2-8cfc-4f87-af7d-d4224e8c7645.gif"/>

Code: 
```jsx
      <Dialog.Container
        visible={visible}
        statusBarTranslucent
        onRequestClose={() => {
          setVisible(false);
        }}
      >
      ...
      </Dialog.Container>
```