### PR TITLE
Change style propType of Input from View to Text

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -70,6 +70,7 @@ DialogInput.propTypes = {
   wrapperStyle: ViewPropTypes.style,
   numberOfLines: PropTypes.number,
   multiline: PropTypes.bool,
+  style: Text.propTypes.style
 };
 
 DialogInput.displayName = "DialogInput";

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -70,7 +70,7 @@ DialogInput.propTypes = {
   wrapperStyle: ViewPropTypes.style,
   numberOfLines: PropTypes.number,
   multiline: PropTypes.bool,
-  style: (Text as any).propTypes.style
+  style: (Text as any).propTypes.style,
 };
 
 DialogInput.displayName = "DialogInput";

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -70,7 +70,7 @@ DialogInput.propTypes = {
   wrapperStyle: ViewPropTypes.style,
   numberOfLines: PropTypes.number,
   multiline: PropTypes.bool,
-  style: Text.propTypes.style
+  style: (Text as any).propTypes.style
 };
 
 DialogInput.displayName = "DialogInput";


### PR DESCRIPTION


# Overview

Change propTypes of Input to allow styles like fontSize to be passed.

Note that for some strange reason, TextPropTypes doesn't exist, I tried but it's undefined. So I am using Text.propTypes.style workaround.
https://stackoverflow.com/questions/48565754/react-native-prop-type-for-text-style

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

<!-- NOTES ON CUSTOMIZATIONS: The goal of this library is to achieve a native look and feeling. At the current state we're not looking into increasing the customization options. If you're exposing new customizations options, please let us know in details WHY you think they're needed. Thanks! -->
