### PR TITLE
fix: ios description platform color

### DIFF
--- a/src/Description.tsx
+++ b/src/Description.tsx
@@ -31,7 +31,7 @@ const buildStyles: StyleBuilder = (isDark) =>
     text: Platform.select({
       ios: {
         textAlign: "center",
-        color: PlatformColor("secondaryLabel"),
+        color: PlatformColor("label"),
         fontSize: 13,
         marginTop: 4,
       },


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

On iOS, description text has too low contrast and doesn't use the same Platform color as the doc screenshots show. 

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

# Before 

![image](https://user-images.githubusercontent.com/26413496/153577705-29cfe9e4-84e8-4c4e-af0c-f0fad3c02043.png)

# After

![image](https://user-images.githubusercontent.com/26413496/153579139-e478c6ca-0aad-4358-a346-3dc0719402e9.png)

<!-- NOTES ON CUSTOMIZATIONS: The goal of this library is to achieve a native look and feeling. At the current state we're not looking into increasing the customization options. If you're exposing new customizations options, please let us know in details WHY you think they're needed. Thanks! -->
