### PR TITLE
chore: remove usage of PropTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "devDependencies": {
         "@semantic-release/changelog": "^5.0.1",
         "@semantic-release/git": "^9.0.0",
-        "@types/prop-types": "^15.7.3",
         "@types/react": "^17.0.3",
         "@types/react-native": "^0.64.2",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
@@ -23,7 +22,6 @@
         "husky": "^4.2.5",
         "lint-staged": "^10.2.11",
         "prettier": "^2.0.5",
-        "prop-types": "^15.7.2",
         "semantic-release": "^17.1.2",
         "typescript": "^4.2.4"
       },
@@ -11998,6 +11996,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22749,6 +22752,7 @@
       "integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -22795,6 +22799,7 @@
       "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
-    "@types/prop-types": "^15.7.3",
     "@types/react": "^17.0.3",
     "@types/react-native": "^0.64.2",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
@@ -49,7 +48,6 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",
-    "prop-types": "^15.7.2",
     "semantic-release": "^17.1.2",
     "typescript": "^4.2.4"
   },

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -7,11 +7,9 @@ import {
   TouchableOpacity,
   PlatformColor,
   TextProps,
-  TextPropTypes,
   ColorValue,
 } from "react-native";
 import useTheme, { StyleBuilder } from "./useTheme";
-import PropTypes from "prop-types";
 
 const COLOR = Platform.OS === "ios" ? "#007ff9" : "#169689";
 
@@ -23,7 +21,7 @@ export interface DialogButtonProps extends TextProps {
   onPress: () => void;
 }
 
-const DialogButton: React.FC<DialogButtonProps> = (props) => {
+const DialogButton = (props: DialogButtonProps) => {
   const {
     label,
     color = COLOR,
@@ -50,15 +48,6 @@ const DialogButton: React.FC<DialogButtonProps> = (props) => {
       </Text>
     </TouchableOpacity>
   );
-};
-
-DialogButton.propTypes = {
-  ...TextPropTypes,
-  label: PropTypes.string.isRequired,
-  color: PropTypes.string,
-  bold: PropTypes.bool,
-  disabled: PropTypes.bool,
-  onPress: PropTypes.func.isRequired,
 };
 
 DialogButton.displayName = "DialogButton";

--- a/src/CodeInput.tsx
+++ b/src/CodeInput.tsx
@@ -9,12 +9,10 @@ import {
   PlatformColor,
   TextInputProps,
   ViewStyle,
-  ViewPropTypes,
   StyleProp,
   TextStyle,
 } from "react-native";
 import useTheme from "./useTheme";
-import PropTypes from "prop-types";
 
 export interface DialogCodeInputProps extends TextInputProps {
   wrapperStyle?: StyleProp<ViewStyle>;
@@ -25,7 +23,7 @@ export interface DialogCodeInputProps extends TextInputProps {
   onCodeChange?: (code: string) => void;
 }
 
-const DialogCodeInput: React.FC<DialogCodeInputProps> = (props) => {
+const DialogCodeInput = (props: DialogCodeInputProps) => {
   const {
     style,
     wrapperStyle,
@@ -104,18 +102,6 @@ const DialogCodeInput: React.FC<DialogCodeInputProps> = (props) => {
     </View>
   );
 };
-
-DialogCodeInput.propTypes = {
-  ...ViewPropTypes,
-  wrapperStyle: ViewPropTypes.style,
-  digitContainerStyle: ViewPropTypes.style,
-  digitContainerFocusedStyle: ViewPropTypes.style,
-  digitStyle: ViewPropTypes.style,
-  codeLength: PropTypes.number,
-  onCodeChange: PropTypes.func,
-  style: (Text as any).propTypes.style,
-};
-
 DialogCodeInput.displayName = "DialogCodeInput";
 
 const buildStyles = (isDark: boolean) =>

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -8,11 +8,9 @@ import {
   PlatformColor,
   ViewStyle,
   StyleProp,
-  ViewPropTypes,
 } from "react-native";
 import Modal from "./Modal";
 import useTheme, { StyleBuilder } from "./useTheme";
-import PropTypes from "prop-types";
 import DialogTitle, { DialogTitleProps } from "./Title";
 import DialogDescription, { DialogDescriptionProps } from "./Description";
 import DialogButton, { DialogButtonProps } from "./Button";
@@ -41,7 +39,7 @@ export type DialogContainerProps = PropsWithChildren<{
   useNativeDriver?: boolean;
 }>;
 
-const DialogContainer: React.FC<DialogContainerProps> = (props) => {
+const DialogContainer = (props: DialogContainerProps) => {
   const {
     blurComponentIOS,
     buttonSeparatorStyle,
@@ -134,21 +132,6 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
       </KeyboardAvoidingView>
     </Modal>
   );
-};
-
-DialogContainer.propTypes = {
-  blurComponentIOS: PropTypes.node,
-  buttonSeparatorStyle: ViewPropTypes.style,
-  contentStyle: ViewPropTypes.style,
-  footerStyle: ViewPropTypes.style,
-  headerStyle: ViewPropTypes.style,
-  blurStyle: ViewPropTypes.style,
-  visible: PropTypes.bool,
-  verticalButtons: PropTypes.bool,
-  onBackdropPress: PropTypes.func,
-  keyboardVerticalOffset: PropTypes.number,
-  useNativeDriver: PropTypes.bool,
-  children: PropTypes.node.isRequired,
 };
 
 const buildStyles: StyleBuilder = () =>

--- a/src/Description.tsx
+++ b/src/Description.tsx
@@ -1,17 +1,17 @@
 import * as React from "react";
+import { PropsWithChildren } from "react";
 import {
   Platform,
   StyleSheet,
   Text,
   PlatformColor,
-  TextPropTypes,
   TextProps,
 } from "react-native";
 import useTheme, { StyleBuilder } from "./useTheme";
 
-export type DialogDescriptionProps = TextProps;
+export type DialogDescriptionProps = PropsWithChildren<TextProps>;
 
-const DialogDescription: React.FC<DialogDescriptionProps> = (props) => {
+const DialogDescription = (props: DialogDescriptionProps) => {
   const { style, children, ...nodeProps } = props;
   const { styles } = useTheme(buildStyles);
 
@@ -21,8 +21,6 @@ const DialogDescription: React.FC<DialogDescriptionProps> = (props) => {
     </Text>
   );
 };
-
-DialogDescription.propTypes = TextPropTypes;
 
 DialogDescription.displayName = "DialogDescription";
 

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -9,11 +9,9 @@ import {
   PlatformColor,
   TextInputProps,
   ViewStyle,
-  ViewPropTypes,
   StyleProp,
 } from "react-native";
 import useTheme, { StyleBuilder } from "./useTheme";
-import PropTypes from "prop-types";
 
 export interface DialogInputProps extends TextInputProps {
   label?: ReactNode;
@@ -21,7 +19,7 @@ export interface DialogInputProps extends TextInputProps {
   textInputRef?: LegacyRef<TextInput>;
 }
 
-const DialogInput: React.FC<DialogInputProps> = (props) => {
+const DialogInput = (props: DialogInputProps) => {
   const {
     label,
     style,
@@ -61,16 +59,6 @@ const DialogInput: React.FC<DialogInputProps> = (props) => {
       />
     </View>
   );
-};
-
-DialogInput.propTypes = {
-  ...ViewPropTypes,
-  label: PropTypes.string,
-  textInputRef: PropTypes.any,
-  wrapperStyle: ViewPropTypes.style,
-  numberOfLines: PropTypes.number,
-  multiline: PropTypes.bool,
-  style: (Text as any).propTypes.style,
 };
 
 DialogInput.displayName = "DialogInput";

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Component } from "react";
-import PropTypes from "prop-types";
 import {
   Animated,
   Easing,
@@ -10,7 +9,6 @@ import {
   StyleProp,
   StyleSheet,
   TouchableWithoutFeedback,
-  ViewPropTypes,
   ViewStyle,
 } from "react-native";
 
@@ -73,14 +71,6 @@ interface ModalState {
 }
 
 export class Modal extends Component<ModalProps, ModalState> {
-  static propTypes = {
-    onBackdropPress: PropTypes.func,
-    onHide: PropTypes.func,
-    visible: PropTypes.bool,
-    contentStyle: ViewPropTypes.style,
-    useNativeDriver: PropTypes.bool,
-  };
-
   static defaultProps: Partial<ModalProps> = {
     onBackdropPress: () => null,
     onHide: () => null,

--- a/src/Switch.tsx
+++ b/src/Switch.tsx
@@ -8,16 +8,14 @@ import {
   View,
   PlatformColor,
   SwitchProps,
-  ViewPropTypes,
 } from "react-native";
 import useTheme, { StyleBuilder } from "./useTheme";
-import PropTypes from "prop-types";
 
 export interface DialogSwitchProps extends SwitchProps {
   label?: ReactNode;
 }
 
-const DialogSwitch: React.FC<DialogSwitchProps> = (props) => {
+const DialogSwitch = (props: DialogSwitchProps) => {
   const { label, ...nodeProps } = props;
   const { styles } = useTheme(buildStyles);
   return (
@@ -26,11 +24,6 @@ const DialogSwitch: React.FC<DialogSwitchProps> = (props) => {
       <Switch {...nodeProps} />
     </View>
   );
-};
-
-DialogSwitch.propTypes = {
-  ...ViewPropTypes,
-  label: PropTypes.node,
 };
 
 DialogSwitch.displayName = "DialogSwitch";

--- a/src/Title.tsx
+++ b/src/Title.tsx
@@ -1,17 +1,17 @@
 import * as React from "react";
+import { PropsWithChildren } from "react";
 import {
   Platform,
   StyleSheet,
   Text,
   PlatformColor,
-  TextPropTypes,
   TextProps,
 } from "react-native";
 import useTheme, { StyleBuilder } from "./useTheme";
 
-export type DialogTitleProps = TextProps;
+export type DialogTitleProps = PropsWithChildren<TextProps>;
 
-const DialogTitle: React.FC<DialogTitleProps> = (props) => {
+const DialogTitle = (props: DialogTitleProps) => {
   const { style, children, ...nodeProps } = props;
   const { styles } = useTheme(buildStyles);
 
@@ -21,8 +21,6 @@ const DialogTitle: React.FC<DialogTitleProps> = (props) => {
     </Text>
   );
 };
-
-DialogTitle.propTypes = TextPropTypes;
 
 DialogTitle.displayName = "DialogTitle";
 


### PR DESCRIPTION
# Overview

fixes #131

eslint complained about the rule [prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md) when I removed the PropTypes, eventhough as I understand it should work with TypeScript. I ended up removing the usage of `React.FC` to fix this. Let me know if that's not ok and we can try to find a different solution. (Maybe just disable the rule?)
