### PR TITLE
Add customizable labelStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ const styles = StyleSheet.create({
 | Name         | Type   | Default   | Description                                 |
 | ------------ | ------ | --------- | ------------------------------------------- |
 | label        | string | undefined | The input floating label                    |
+| labelStyle   | any    | undefined | The style applied to the input label Text |
 | wrapperStyle | any    | undefined | The style applied to the input wrapper View |
 | textInputRef | ref    | undefined | Ref to the input                            |
 

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -17,6 +17,7 @@ import PropTypes from "prop-types";
 
 export interface DialogInputProps extends TextInputProps {
   label?: ReactNode;
+  labelStyle?: StyleProp;
   wrapperStyle?: StyleProp<ViewStyle>;
   textInputRef?: LegacyRef<TextInput>;
 }
@@ -25,6 +26,7 @@ const DialogInput: React.FC<DialogInputProps> = (props) => {
   const {
     label,
     style,
+    labelStyle,
     wrapperStyle,
     textInputRef,
     multiline,
@@ -37,7 +39,7 @@ const DialogInput: React.FC<DialogInputProps> = (props) => {
   const { styles, isDark } = useTheme(buildStyles);
   return (
     <View style={[styles.textInputWrapper, wrapperStyle]}>
-      {label && <Text style={styles.label}>{label}</Text>}
+      {label && <Text style={[styles.label, labelStyle]}>{label}</Text>}
       <TextInput
         ref={textInputRef}
         placeholderTextColor={
@@ -67,6 +69,7 @@ DialogInput.propTypes = {
   ...ViewPropTypes,
   label: PropTypes.string,
   textInputRef: PropTypes.any,
+  labelStyle: (Text as any).propTypes.style,
   wrapperStyle: ViewPropTypes.style,
   numberOfLines: PropTypes.number,
   multiline: PropTypes.bool,


### PR DESCRIPTION
# Overview

Add an additional style prop to the `Dialog.Input`

# Test Plan

**Why:** I'm trying to implement custom styles for when users use dark/light mode and the system is set to the opposite color scheme - but I've hit a wall with trying to style the inputs. Basically everything else seems to be possible with the current API, but changing the label color is not currently possible.
