### PR TITLE
Determine where children belong using .displayName

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -62,14 +62,14 @@ const DialogContainer: React.FC<DialogContainerProps> = (props) => {
   const { styles } = useTheme(buildStyles);
   React.Children.forEach(children, (child) => {
     if (typeof child === "object" && child !== null && "type" in child) {
-      switch (child.type) {
-        case DialogTitle:
+      switch (child.type.displayName) {
+        case DialogTitle.displayName:
           titleChildrens.push(child as TitleElement);
           return;
-        case DialogDescription:
+        case DialogDescription.displayName:
           descriptionChildrens.push(child as DescriptionElement);
           return;
-        case DialogButton:
+        case DialogButton.displayName:
           if (Platform.OS === "ios" && buttonChildrens.length > 0) {
             buttonChildrens.push(
               <View


### PR DESCRIPTION
# Overview

This fixes a sub-issue raised within #141: https://github.com/mmazzarolo/react-native-dialog/issues/141#issuecomment-1148278458

# Test Plan

Changes were verified in our internal codebase. These lines were added to a PR, but not tested separately/a second time after being added to the PR.