### PR TITLE
Fix android modal width

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -166,6 +166,7 @@ const buildStyles: StyleBuilder = () =>
         overflow: "hidden",
         elevation: 4,
         minWidth: 300,
+        width: 300,
       },
       web: {
         flexDirection: "column",
@@ -176,6 +177,7 @@ const buildStyles: StyleBuilder = () =>
         overflow: "hidden",
         elevation: 4,
         minWidth: 300,
+        width: 300,
       },
       default: {},
     }),


### PR DESCRIPTION
For iOS platform we have fixed width 
<img width="386" alt="image" src="https://user-images.githubusercontent.com/10028441/209297185-ac0356cd-94ef-4565-bfc5-4562c481f9b8.png">
in this case when we have dynamic content like input and user type something  modal container not increase witdh, so we need to do the same for other platform.

Before
https://user-images.githubusercontent.com/10028441/209297979-cc201a21-63e5-4237-ba0d-4a9f7899f094.mov

After
https://user-images.githubusercontent.com/10028441/209298011-543a4ed1-f20e-49b2-805a-e84fa27a20da.mov





# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

<!-- NOTES ON CUSTOMIZATIONS: The goal of this library is to achieve a native look and feeling. At the current state we're not looking into increasing the customization options. If you're exposing new customizations options, please let us know in details WHY you think they're needed. Thanks! -->
