### PR TITLE
Permit updating the value of code inputs

### DIFF
--- a/src/CodeInput.tsx
+++ b/src/CodeInput.tsx
@@ -23,6 +23,7 @@ export interface DialogCodeInputProps extends TextInputProps {
   digitStyle?: StyleProp<TextStyle>;
   codeLength?: number;
   onCodeChange?: (code: string) => void;
+  value?: string;
 }
 
 const DialogCodeInput: React.FC<DialogCodeInputProps> = (props) => {
@@ -35,12 +36,16 @@ const DialogCodeInput: React.FC<DialogCodeInputProps> = (props) => {
     digitStyle,
     codeLength = 4,
     onCodeChange,
+    value = "",
     ...nodeProps
   } = props;
   const { styles } = useTheme(buildStyles);
   const codeRef = React.useRef<TextInput>(null);
   const [containerIsFocused, setContainerIsFocused] = React.useState(autoFocus);
-  const [code, setCode] = React.useState("");
+  const [code, setCode] = React.useState(value);
+  React.useEffect(() => {
+    setCode(value);
+  }, [value]);
   const codeDigitsArray = new Array(codeLength).fill(0);
   const emptyInputChar = " ";
   const handleContainerPress = () => {
@@ -98,6 +103,7 @@ const DialogCodeInput: React.FC<DialogCodeInputProps> = (props) => {
         onSubmitEditing={handleOnBlur}
         maxLength={codeLength}
         onChangeText={onCodeChangePress}
+        value={value}
         {...nodeProps}
       />
     </View>


### PR DESCRIPTION
Prior to this commit, there is no way to programmatically update the value of a CodeInput.

After this commit, sending a value prop to the CodeInput component allows us to control the value displayed in the CodeInput, by changing the content of the variable that's set as the CodeInput's value prop.

# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

I wanted to be able to change the value displayed by a CodeInput component. Using TextInput's `value` prop didn't work because there's local state in the CodeInput component that controls the value that's displayed.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I verified that my changes work by [forking your repo](https://github.com/pachun/react-native-dialog), creating a branch ([`permit-code-input-value-changes`](https://github.com/pachun/react-native-dialog/tree/permit-code-input-value-changes) - which is the fork I'd suggesting we merge in this PR) and committing my changes to that branch. Rather than publish the fork to NPM, [I created another branch](https://github.com/pachun/react-native-dialog/tree/include-lib) (on top of the previous one), on which I ran `npm run build`, removed `/lib` from the .gitignore, and pushed back up to my repo. I think we don't want the /lib checked in here, so I excluded it from this PR, but the only way I knew to test my changes without publishing to NPM was to include lib in a branch and then add my fork as a dependency to the project I'm working on by running `yarn add pachun/react-native-dialog#include-lib`. Once the fork was added as a dependency of the project I'm working on, I was able to control the value displayed by CodeInput components by doing:

```react
  const [confirmationCode, setConfirmationCode] = React.useState("")

// ...

<Dialog.CodeInput
  autoFocus
  value={confirmationCode}
  onChangeText={setConfirmationCode}
  testID="Confirmation Code Input"
/>
```

Now, anywhere where I call `setConfirmationCode(__value__)`, will update the value displayed by the CodeInput component to `__value__`, which I couldn't find a way to do prior to making the changes in this fork.

<!-- NOTES ON CUSTOMIZATIONS: The goal of this library is to achieve a native look and feeling. At the current state we're not looking into increasing the customization options. If you're exposing new customizations options, please let us know in details WHY you think they're needed. Thanks! -->


Other notes about the change:

I really dislike `useEffects`. I added one in this PR because it was the easiest way to get the behavior that I needed and get back to working on my project. I'm definitely open to implementing this any other way, possibly conforming to a project convention that I missed somewhere.

EDIT:

Since this has been in review for a bit: For anyone else wanting this feature now, you can also do `yarn add pachun/react-native-dialog#include-lib` or the NPM equivalent `npm install pachun/react-native-dialog#include-lib --save` to install of version of react-native-dialog that'll let you control the value of a `CodeInput` component.